### PR TITLE
Split vendored frameworks into separate targets

### DIFF
--- a/Sources/PodToBUILD/BuildFile.swift
+++ b/Sources/PodToBUILD/BuildFile.swift
@@ -195,7 +195,14 @@ public struct PodBuildFile: SkylarkConvertible {
 
     private static func vendoredFrameworks(withPodspec spec: PodSpec) -> [BazelTarget] {
         let frameworks = spec.attr(\.vendoredFrameworks)
-        return frameworks.isEmpty ? [] : [AppleFrameworkImport(name: "\(spec.moduleName ?? spec.name)_VendoredFrameworks", frameworkImports: frameworks)]
+        return frameworks.map {
+            $0.map {
+                let frameworkName = URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent
+                return AppleFrameworkImport(name: "\(spec.moduleName ?? spec.name)_\(frameworkName)_VendoredFrameworks", 
+                                            frameworkImport: AttrSet(basic: $0))
+            }
+        }
+        .basic ?? []
     }
 
     private static func vendoredLibraries(withPodspec spec: PodSpec) -> [BazelTarget] {

--- a/Sources/PodToBUILD/ObjcLibrary.swift
+++ b/Sources/PodToBUILD/ObjcLibrary.swift
@@ -91,7 +91,7 @@ public struct ConfigSetting: BazelTarget {
 // https://github.com/bazelbuild/rules_apple/blob/818e795208ae3ca1cf1501205549d46e6bc88d73/doc/rules-general.md#apple_static_framework_import
 public struct AppleFrameworkImport: BazelTarget {
     public let name: String // A unique name for this rule.
-    public let frameworkImports: AttrSet<[String]> // The list of files under a .framework directory which are provided to Objective-C targets that depend on this target.
+    public let frameworkImport: AttrSet<String> // The list of files under a .framework directory which are provided to Objective-C targets that depend on this target.
 
     public var acknowledged: Bool {
         return true
@@ -113,8 +113,8 @@ public struct AppleFrameworkImport: BazelTarget {
                 arguments: [SkylarkFunctionArgument]([
                     .named(name: "name", value: .string(name)),
                     .named(name: isXCFramework ? "xcframework_imports": "framework_imports",
-                           value: frameworkImports.map {
-                                  GlobNode(include: Set($0.map { $0 + "/**" }))
+                           value: frameworkImport.map {
+                                  GlobNode(include: Set([$0 + "/**"]))
                             }.toSkylark()),
                     .named(name: "visibility", value: .list(["//visibility:public"]))
                 ])

--- a/Sources/RepoToolsCore/RepoActions.swift
+++ b/Sources/RepoToolsCore/RepoActions.swift
@@ -456,13 +456,10 @@ public enum RepoActions {
                     })
                 }
                 if let fwImport = convertible as? AppleFrameworkImport {
-                    globResults.formUnion(fwImport.frameworkImports.trivialize(into: Set<String>()) {
+                    globResults.formUnion(fwImport.frameworkImport.trivialize(into: Set<String>()) {
                         accum, next in
                         let HeaderFileTypes = Set([".h", ".hpp", ".hxx"])
-                        let imports = next.reduce(into: Set<String>()) {
-                            accum, nextImport in
-                            accum.formUnion(Set(HeaderFileTypes.map { nextImport + "/**/*" + $0 }))
-                        }
+                        let imports = Set(HeaderFileTypes.map { next + "/**/*" + $0 })
                         let headersDir = GlobNode(include: imports)
                         accum.formUnion(headersDir.sourcesOnDisk())
                     })


### PR DESCRIPTION
Since `apple_static_framework_import` supports only one framework per target

https://github.com/bazelbuild/rules_apple/blob/master/apple/internal/apple_framework_import.bzl#L135